### PR TITLE
Remove --no-suggest from composer commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,15 +46,15 @@ jobs:
 
       - name: "Install lowest dependencies"
         if: ${{ matrix.dependencies == 'lowest' }}
-        run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest --ansi"
+        run: "composer update --prefer-lowest --no-interaction --no-progress --ansi"
 
       - name: "Install highest dependencies"
         if: ${{ matrix.dependencies == 'highest' }}
-        run: "composer update --no-interaction --no-progress --no-suggest --ansi"
+        run: "composer update --no-interaction --no-progress --ansi"
 
       - name: "Install locked dependencies"
         if: ${{ matrix.dependencies == 'locked' }}
-        run: "composer install --no-interaction --no-progress --no-suggest --ansi"
+        run: "composer install --no-interaction --no-progress --ansi"
 
       - name: "Validate Composer dependencies"
         run: "composer validate"


### PR DESCRIPTION
Deprecated, see https://php.watch/articles/composer-2#:~:text=--no-suggest%20option%20is,saying%20this%20option%20is%20deprecated%3A&text=It%20has%20no%20effect%20and%20will%20break%20in%20Composer%203.