### PR TITLE
Run local-php-security-checker in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: "Run linting"
         run: "composer lint"
 
+      - name: "Run security check"
+        run: "composer security:check"
+
       - name: "Run coding style"
         if: ${{ matrix.php-version != '8.1' }} # php-cs-fixer does not run on 8.1 yet
         run: "composer code-style:check"

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   "prefer-stable": true,
   "scripts": {
     "security:check": [
-      "local-php-security-checker"
+      "bin/local-php-security-checker"
     ],
     "code-style:fix": [
       "PHP_CS_FIXER_FUTURE_MODE=1 php-cs-fixer fix --diff --ansi --using-cache=no"


### PR DESCRIPTION
This was unintentionally omitted when swapping over to GitHub Actions.