### PR TITLE
Use a separate PHPStan config for Rector

### DIFF
--- a/phpstan-rector.neon
+++ b/phpstan-rector.neon
@@ -1,0 +1,6 @@
+includes:
+  - vendor/phpstan/phpstan-phpunit/extension.neon
+  - vendor/phpstan/phpstan-strict-rules/rules.neon
+
+parameters:
+    level: max

--- a/rector.php
+++ b/rector.php
@@ -13,7 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::PATHS, [__DIR__.'/src', __DIR__.'/tests']);
     $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_74);
-    $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__.'/phpstan.neon');
+    $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__.'/phpstan-rector.neon');
     $parameters->set(Option::PARALLEL, true);
     $parameters->set(Option::SKIP, [
         DateTimeToDateTimeInterfaceRector::class,


### PR DESCRIPTION
1.5.x Bleeding Edge config causes issues with bring-along version of PHPStan in use by Rector, work around this (or realistically, it should always have been this way) by using a separate configuration file.