### PR TITLE
chore(DEVOPS-10688): rename deprecated app-id input to client-id in create-github-app-token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: generate-token
         with:
-          app-id: ${{ secrets.LENDABOT_APP_ID }}
+          client-id: ${{ secrets.LENDABOT_APP_ID }}
           private-key: ${{ secrets.LENDABOT_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5


### PR DESCRIPTION
# [DEVOPS-10688](https://lendable-uk.atlassian.net/browse/DEVOPS-10688)

## Changes
- Rename the deprecated `app-id` input to `client-id` in `actions/create-github-app-token` (already pinned to v3; value unchanged, auth unaffected). Removes the v3 deprecation warning from CI logs.

## Context
Pure key rename — GitHub accepts your existing App ID value as the JWT issuer under either key. Part of the org-wide cleanup DEVOPS-10688. Opened as draft pending review.

[DEVOPS-10688]: https://lendable-uk.atlassian.net/browse/DEVOPS-10688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ